### PR TITLE
Revert "chore(deps): bump ink from 5.2.1 to 6.8.0"

### DIFF
--- a/packages/everything-dev/package.json
+++ b/packages/everything-dev/package.json
@@ -108,7 +108,7 @@
     "every-plugin": "workspace:*",
     "gradient-string": "^3.0.0",
     "hono": "^4.7.11",
-    "ink": "^6.8.0",
+    "ink": "^5.2.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "zod": "^3.25.0"


### PR DESCRIPTION
Reverts NEARBuilders/everything-dev#8