### PR TITLE
fix: bos dev regenerates .env.example with all declared secrets

### DIFF
--- a/.changeset/brave-infra-secrets.md
+++ b/.changeset/brave-infra-secrets.md
@@ -1,0 +1,5 @@
+---
+"everything-dev": patch
+---
+
+`bos dev` now generates `.env.example` and `docker-compose.yml` via the full runtime secret set (`writeGeneratedInfra`) instead of only auto-generated database/redis URLs and `CORS_ORIGIN`. This fixes regenerated files silently dropping host/API/auth/plugin secrets (e.g. `BETTER_AUTH_SECRET`, `CSP_STRICT`, GitHub/Google client secrets) that remain declared in `bos.config.json`.

--- a/packages/everything-dev/src/plugin.ts
+++ b/packages/everything-dev/src/plugin.ts
@@ -17,7 +17,6 @@ import {
 import {
   ensureEnvFile,
   loadProjectEnv,
-  materializeInfraPlan,
   syncGeneratedInfra,
   writeGeneratedInfra,
 } from "./cli/infra";
@@ -712,25 +711,7 @@ export default createPlugin({
       }
 
       const services = buildServiceDescriptorMapFromPlan(plan, { ssr, proxy });
-      materializeInfraPlan(
-        deps.configDir,
-        plan.envGenerated,
-        plan.composeModel.databases.map((d) => ({
-          serviceName: `postgres-${d.slug.replace(/_/g, "-")}`,
-          containerName: d.containerName,
-          port: d.port,
-          volumeName: d.volumeName,
-          databaseName: d.dbName,
-        })),
-        plan.composeModel.redis.map((r) => ({
-          serviceName: `redis-${r.slug.replace(/_/g, "-")}`,
-          containerName: r.containerName,
-          port: r.port,
-          volumeName: r.volumeName,
-        })),
-        plan.runtimeConfig.account,
-        plan.resolvedPorts.host,
-      );
+      writeGeneratedInfra(deps.configDir, plan.runtimeConfig);
       ensureEnvFile(deps.configDir);
       loadProjectEnv(deps.configDir);
 


### PR DESCRIPTION
## What

Fixes `bos dev` overwriting `.env.example` / `docker-compose.yml` with only auto-generated database/redis URLs and `CORS_ORIGIN`.

## Problem

The `bos dev` handler called `materializeInfraPlan` with `plan.envGenerated` (built by `buildEnvGenerated` in `planner.ts`), which only includes:
- `CORS_ORIGIN`
- database URLs
- redis URLs

All host/API/auth/plugin secrets (e.g. `BETTER_AUTH_SECRET`, `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_SECRET`, `TENANT_WHITELIST`, `ALLOW_UNTRUSTED_SSR`, `CSP_STRICT`, etc.) dropped out of the regenerated `.env.example`, despite remaining declared in `bos.config.json`. Anyone following the onboarding (`cp .env.example .env`) would be missing required secrets.

`bos start` and `bos sync` already generate these files correctly via `writeGeneratedInfra` → `syncGeneratedInfra` → `getSecretGroups(runtimeConfig)`, which enumerates **all** secret sections (app.host, app.api, app.auth, plugins.*).

## Fix

Swap the dev handler from `materializeInfraPlan` to `writeGeneratedInfra(deps.configDir, plan.runtimeConfig)` so all commands share the same complete secret-collection path. Port assignments stay consistent since both read from the same persisted `.bos/infra-state.json`.

## Changeset

`everything-dev` patch.

## Tests

`bun typecheck` clean. `bun test` — all infra/planner tests pass; 10 pre-existing failures are unrelated (vi.hoisted/integrity framework-compat issues).