### PR TITLE
fix(host): add wss: to CSP connect-src for plugin WebSocket support

### DIFF
--- a/.changeset/wild-ghosts-brake.md
+++ b/.changeset/wild-ghosts-brake.md
@@ -1,0 +1,5 @@
+---
+"host": patch
+---
+
+Add `wss:` scheme to CSP `connect-src` directive to allow WebSocket connections (e.g. nostr relays, streaming APIs). Plugins declaring `connectSrc` with `wss://` URLs now work through the host without per-request CSP overrides.

--- a/host/src/middleware/security.ts
+++ b/host/src/middleware/security.ts
@@ -159,6 +159,7 @@ export class SecurityMiddleware extends Context.Tag("host/SecurityMiddleware")<
             connectSrc: [
               "'self'",
               "https:",
+              "wss:",
               ...uniqueOrigins,
               ...wsOrigins,
               ...cdnOrigins,


### PR DESCRIPTION
## Summary

Adds `wss:` scheme to the CSP `connect-src` directive in the host security middleware, alongside the existing `https:` scheme-wide allowance.

## Context

Plugins that need WebSocket connections (e.g. nostr relays, streaming APIs) were failing through the host because the CSP `connect-src` directive didn't include `wss:`. While plugins can declare `connectSrc` in their config, the CSP middleware is built once at boot time from the base config — tenant-specific `connectSrc` values never reached the response headers.

Adding `wss:` scheme-wide is consistent with the existing `https:` permissiveness in the same directive, and immediately unblocks all WebSocket connections without requiring a per-request CSP refactor.

## Changes

- `host/src/middleware/security.ts`: Added `"wss:"` to `connectSrc` array
- `.changeset/wild-ghosts-brake.md`: Changeset

## Testing

- `bun typecheck` — passes
- `bun lint` — passes